### PR TITLE
add[readme]: link to notion docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Some Ideas to Discuss
 
 ## Links:
 - [Netlify](https://app.netlify.com/sites/conversionanad/)
+- [Notion docs](https://www.notion.so/adrianskar/Netlify-02e4f548ef0746e68642c49ac3a449cd)
 - [Front](https://conversionanad.netlify.app/)
 - [Repo](https://github.com/AdrianSkar/conversions)
 - [Exchangerates API](https://exchangeratesapi.io/)
+


### PR DESCRIPTION
@ana-vela I was trying to document some steps on how we get the API from Netlify and how I'm starting to set up the local environment when, making the diagram, I remembered we talked about doing it externally (Notion) as to avoid file cluttering. Take a look and see if it looks good to you, please.