### PR TITLE
add[npm]: installation and ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 api.js
+
+# Local Netlify folder
+.netlify

--- a/app.js
+++ b/app.js
@@ -1,0 +1,1 @@
+console.log('test');

--- a/func/curr_api.js
+++ b/func/curr_api.js
@@ -1,4 +1,4 @@
-// /.netlify/functions/yep
+// /.netlify/functions/curr_api
 
 exports.handler = function (event, context, callback) {
 	//event - similar to express Request object

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "conversions",
+  "version": "1.0.0",
+  "description": "Practice APIs and front-end in general",
+  "main": "api.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AdrianSkar/conversions.git"
+  },
+  "author": "Ana Vela, Adrian Skar",
+  "bugs": {
+    "url": "https://github.com/AdrianSkar/conversions/issues"
+  },
+  "homepage": "https://github.com/AdrianSkar/conversions#readme"
+}


### PR DESCRIPTION
- Install npm and set the package.json file.
- `/func/curr_api.js` gets the ENV API key from the server and exports
	the function.
- Add `./netlify` config folder created by `netlify-cli` to `.gitignore`
	as it contains the site ID.
- Test `netlify-cli` (locally) to check the app works properly as shown
	in our [Notion docs](https://www.notion.so/adrianskar/Netlify-setup-and-deploy-02e4f548ef0746e68642c49ac3a449cd)(updated).